### PR TITLE
Auto-detect free ports in bin/dev for worktree compatibility

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
 
 vite: bin/vite dev
-web: bin/thrust bin/rails s
+web: bin/rails s -p ${PORT:-3000}

--- a/bin/dev
+++ b/bin/dev
@@ -11,7 +11,6 @@ free_port() {
 }
 
 # Rails port — honour explicit PORT, otherwise auto-detect from 3000.
-# Thruster (bin/thrust) will listen on PORT and proxy to Puma on PORT+100.
 if [ -z "$PORT" ]; then
   PORT=$(free_port 3000)
 fi
@@ -31,7 +30,7 @@ echo ""
 
 if command -v overmind 1> /dev/null 2>&1
 then
-  overmind start -f Procfile.dev "$@"
+  overmind start -f Procfile.dev --no-port "$@"
   exit $?
 fi
 


### PR DESCRIPTION
## Problem

Running `bin/dev` in a worktree while the main app is already running failed with port conflicts:

- Vite: `Error: Port 3036 is already in use`
- Rails/Puma: `Address already in use - bind(2) for "127.0.0.1" port 3000`

## Root causes & fixes

### 1. `bin/dev` — auto-detect free ports instead of hardcoding

**Before:** `export PORT="${PORT:-3000}"` — always tried port 3000.

**After:** a `free_port()` function walks up from the given base until it finds an open port, then exports both `PORT` and `VITE_RUBY_PORT`. A worktree started while the main app is running will automatically land on the next free pair (e.g. 3001 / 3037).

```
  App  →  http://localhost:3001
  Vite →  http://localhost:3037
```

The function uses `lsof -iTCP:<port> -sTCP:LISTEN` rather than `nc -z 127.0.0.1` because on macOS the vite dev server binds to `::1` (IPv6 loopback). `nc -z 127.0.0.1` only checks IPv4 and silently returns "port free", causing the worktree to pick the same port as the main app.

### 2. `Procfile.dev` — use the detected port for Rails

**Before:** `web: bin/rails s -p 3000` — hardcoded; ignored `PORT`.

**After:** `web: bin/rails s -p ${PORT:-3000}` — uses the auto-detected port.

Thruster (`bin/thrust`) was briefly used here but is a production-only tool (HTTP/2, TLS, asset caching). It ignores `PORT` and always proxies to `TARGET_PORT=3000`, so it was removed.

### 3. `bin/dev` — pass `--no-port` to overmind

By default, overmind treats `PORT` as a base and assigns each process an incremented value (`base`, `base+100`, …). Without `--no-port`, the `web` process would receive `PORT=3101` instead of `3001`, making `-p $PORT` wrong. `--no-port` lets our manually computed `PORT` flow unchanged to all child processes.

## Test plan

- [x] Start the main app with `bin/dev` — boots on 3000 / 3036 as usual
- [x] Start a worktree with `bin/dev` while the main app is running — boots on next free ports (3001 / 3037) without conflict
- [x] `lsof` correctly detects both IPv4 and IPv6 listeners; `nc -z 127.0.0.1` did not

🤖 Generated with [Claude Code](https://claude.com/claude-code)